### PR TITLE
MONGO_URL doesn't get exported to meteor in case it not defined with -e option

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ set -e
 : ${MONGO_URL:="mongodb://${MONGO_PORT_27017_TCP_ADDR}:${MONGO_PORT_27017_TCP_PORT}/${DB}"}
 : ${PORT:="80"}
 
+export MONGO_URL
 
 # If we were given arguments, run them instead
 if [ $? -gt 1 ]; then


### PR DESCRIPTION
Without being exported explicitly it doesn't work with containers linking.
Guess the same issue with PORT env variable.
