### PR TITLE
Fetch meteor bundle using curl instead of wget.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ set -e
 : ${PORT:="80"}
 
 export MONGO_URL
+export PORT
 
 # If we were given arguments, run them instead
 if [ $? -gt 1 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,7 +77,7 @@ fi
 
 if [ -n "${BUNDLE_URL}" ]; then
    echo "Getting Meteor bundle..."
-   wget -O /tmp/bundle.tgz ${BUNDLE_URL}
+   curl -o /tmp/bundle.tgz ${BUNDLE_URL}
    tar xf /tmp/bundle.tgz -C ${APP_DIR}
 fi
 


### PR DESCRIPTION
The base image seems to not actually have wget included, but does have curl.

I have updated the entrypoint.sh to call curl instead.
