### PR TITLE
Allow the version of Meteor to be set at run time

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 The Meteor tool (if required) is now downloaded at runtime, so it is no longer packaged and the version of this docker image does
 not matter for the version of meteor.
 
+You can specify which version of Meteor you want to be installed by setting the `RELEASE` as required.
+
 ## Modes of operation
 
 There are three basic modes of operation for this image:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
    * downloaded with `curl` from `BUNDLE_URL` (if supplied)
    * set `CURL_OPTS` if you need to pass additional parameters
  * Source-based build/execution
-   * Downloads latest Meteor tool at runtime (always the latest tool version, but apps run with their own versions)
+   * Downloads latest Meteor tool at runtime (always the latest tool version unless a `RELEASE` is specified, but apps run with their own versions)
    * Supply source at `SRC_DIR` (defaults to `/src/app`)
    * Supply source from `REPO` (git clone URL)
       * Optionally specify a `DEPLOY_KEY` file for SSH authentication to private repositories
@@ -66,7 +66,17 @@ docker run --rm \
   ulexus/meteor
 ```
 
+### local app source directory on host (/home/user/myapp) with specific Meteor release (1.0.5)
+```sh
+docker run --rm \
+  -e ROOT_URL=http://testsite.com \
+  -v /home/user/myapp:/src/app \
+  -e MONGO_URL=mongodb://mymongoserver.com:27017/appdb \
+  -e MONGO_OPLOG_URL=mongodb://mymongoserver.com:27017/local \
+  -e RELEASE=1.0.5 \
+  ulexus/meteor
+```
+
 ### Unit file
 
 There is also a sample systemd [unit file](meteor.myapp@.service) in the Github repository.
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ set -e
 : ${BRANCH:="master"}
 : ${MONGO_URL:="mongodb://${MONGO_PORT_27017_TCP_ADDR}:${MONGO_PORT_27017_TCP_PORT}/${DB}"}
 : ${PORT:="80"}
+: ${RELEASE:="latest"}
 
 export MONGO_URL
 export PORT
@@ -76,9 +77,18 @@ if [ -n "${METEOR_DIR}" ]; then
    echo "Meteor source found in ${METEOR_DIR}"
    cd ${METEOR_DIR}/..
 
+   # Download Meteor installer
+   echo "Downloading Meteor install script..."
+   curl ${CURL_OPTS} -o /tmp/meteor.sh https://install.meteor.com/
+
    # Install Meteor tool
-   echo "Installing latest Meteor tool..."
-   curl ${CURL_OPTS} https://install.meteor.com/ |sh
+   echo "Installing Meteor ${RELEASE}..."
+   if [ "$RELEASE" != "latest" ]; then
+     sed -i "s/^RELEASE=.*/RELEASE=${RELEASE}/" /tmp/meteor.sh
+   fi
+   chmod +x /tmp/meteor.sh
+   /tmp/meteor.sh
+   rm /tmp/meteor.sh
 
    # Bundle the Meteor app
    echo "Building the bundle...(this may take a while)"


### PR DESCRIPTION
Adds the `RELEASE` environment variable which allows a user to specify which version of Meteor should be downloaded and installed, as opposed to always downloading the latest release.